### PR TITLE
Fix and disable GA workflows

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -8,6 +8,9 @@ on:
 
 jobs:
   CLAAssistant:
+    # Disabled for Hemi as CLA (Contributor License Agreement) is not required.
+    if: false
+
     runs-on: ubuntu-latest
     steps:
       - name: 'CLA Assistant'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -14,6 +14,9 @@ concurrency:
 
 jobs:
   deploy:
+    # Disabled for Hemi as no deployment previews are required.
+    if: false
+
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,7 @@ concurrency:
 
 jobs:
   eslint:
+    permissions: read-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What it solves

Since this is a forked repository, several GitHub Actions workflows do not have enough permissions to run. Therefore, many checks fail.

## How this PR fixes it

CLA and deploy workflows are not required so those are disabled. The linting workflow was granted read permissions. Even when that may not solve its problems, could help identifying what permissions are actually needed.

## Checklist
* [ ] I've tested the branch on mobile 📱
* [ ] I've documented how it affects the analytics (if at all) 📊
* [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
