### PR TITLE
Add Hemi networks and set them as defaults

### DIFF
--- a/patches/@safe-global+protocol-kit+3.1.1.patch
+++ b/patches/@safe-global+protocol-kit+3.1.1.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/@safe-global/protocol-kit/dist/src/utils/eip-3770/config.js b/node_modules/@safe-global/protocol-kit/dist/src/utils/eip-3770/config.js
+index c22dc1e..43f5483 100644
+--- a/node_modules/@safe-global/protocol-kit/dist/src/utils/eip-3770/config.js
++++ b/node_modules/@safe-global/protocol-kit/dist/src/utils/eip-3770/config.js
+@@ -172,6 +172,7 @@ exports.networks = [
+     { chainId: 42161n, shortName: 'arb1' },
+     { chainId: 42170n, shortName: 'arb-nova' },
+     { chainId: 42220n, shortName: 'celo' },
++    { chainId: 43111n, shortName: 'hemi' },
+     { chainId: 43113n, shortName: 'fuji' },
+     { chainId: 43114n, shortName: 'avax' },
+     { chainId: 43288n, shortName: 'boba-avax' },
+@@ -211,6 +212,7 @@ exports.networks = [
+     { chainId: 555666n, shortName: 'eclipset' },
+     { chainId: 622277n, shortName: 'rth' },
+     { chainId: 713715n, shortName: 'sei-devnet' },
++    { chainId: 743111n, shortName: 'hemi-sep' },
+     { chainId: 7225878n, shortName: 'saakuru' },
+     { chainId: 7777777n, shortName: 'zora' },
+     { chainId: 6038361n, shortName: 'azkyt' },

--- a/src/hooks/useChainId.ts
+++ b/src/hooks/useChainId.ts
@@ -8,7 +8,9 @@ import { parsePrefixedAddress } from '@/utils/addresses'
 import useWallet from './wallets/useWallet'
 import useChains from './useChains'
 
-const defaultChainId = IS_PRODUCTION ? chains.eth : chains.sep
+// Once Hemi Mainnet is officially launched, the production default shall be set
+// to `chins.hemi`.
+const defaultChainId = IS_PRODUCTION ? chains['hemi-sep'] : chains['hemi-sep']
 
 // Use the location object directly because Next.js's router.query is available only on mount
 const getLocationQuery = (): ParsedUrlQuery => {


### PR DESCRIPTION
## What it solves

Resolves #7.

## How this PR fixes it

The Hemi Network and Hemi Sepolia were not listed in the known chains the web app uses. This PR patches `@safe-global/protocol-kit` to include both and updates the hook where defaults are defined so the Hemi networks are used instead.

Note that until Hemi Network is officially launched, the default for both staging and production environments will be Hemi Sepolia.