### PR TITLE
Improve the footer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-wallet-web",
-  "homepage": "https://github.com/safe-global/safe-wallet-web",
+  "homepage": "https://github.com/hemilabs/safe-wallet-web",
   "license": "GPL-3.0",
   "version": "1.38.0",
   "type": "module",

--- a/src/components/common/Footer/index.tsx
+++ b/src/components/common/Footer/index.tsx
@@ -75,16 +75,13 @@ const Footer = (): ReactElement | null => {
             </li>
           </>
         ) : (
-          <li>{'This is an unofficial distribution of Safe{Wallet}'}</li>
+          <li>{'This is an unofficial distribution of Safe{Wallet} by Hemi Labs'}</li>
         )}
 
         <li>
-          <ExternalLink href={`${packageJson.homepage}/releases/tag/v${packageJson.version}`} noIcon>
+          <ExternalLink href={`${packageJson.homepage}`} noIcon>
             <SvgIcon component={GitHubIcon} inheritViewBox fontSize="inherit" sx={{ mr: 0.5 }} /> v{packageJson.version}
           </ExternalLink>
-        </li>
-        <li>
-          <AppstoreButton placement="footer" />
         </li>
       </ul>
     </footer>


### PR DESCRIPTION
## What it solves

The default footer has a link to the official Safe app in Apple's App Store. Since Hemi networks are not officially supported yet, the button needs to be removed.

## How this PR fixes it

Removes the button and fixes the link to this repository.

## Screenshots

Before:

<img width="544" alt="image" src="https://github.com/user-attachments/assets/24d04124-a30b-4ef0-b29a-549da33bc16a">

After:

<img width="497" alt="image" src="https://github.com/user-attachments/assets/fbb50fed-6a60-4f89-ac81-625432759e80">
