### PR TITLE
Update the Lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,13 +7,21 @@ concurrency:
 
 jobs:
   eslint:
-    permissions: read-all
+    permissions:
+      checks: write
+      pull-requests: read
+      statuses: write
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - uses: ./.github/workflows/yarn
 
-      - uses: Maggi64/eslint-plus-action@master
+      - uses: CatChen/eslint-suggestion-action@v2
         with:
-          npmInstall: false
+          request-changes: true # optional
+          fail-check: true # optional
+          github-token: ${{ secrets.GITHUB_TOKEN }} # optional
+          directory: './' # optional
+          targets: 'src' # optional


### PR DESCRIPTION
## What it solves

The job at `Lint.jobs.eslint` fails when calling `Maggi64/eslint-plus-action@master` with the following error:

```text
Error: HttpError: Artifact has expired
Error: Artifact has expired
```

## How this PR fixes it

Applying the upstream changes done in [815cb895c](https://github.com/safe-global/safe-wallet-web/commit/815cb895c0269891439fe1b9474bda4038bae4d8#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2) are expected to solve the problem.

## How to test it

See the `eslint` check passing in this PR.