### PR TITLE
Fix test check

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,7 +13,10 @@ concurrency:
 jobs:
   test:
     permissions:
+      contents: read
       checks: write
+      pull-requests: write
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -21,7 +24,7 @@ jobs:
       - uses: ./.github/workflows/yarn
 
       - name: Annotations and coverage report
-        uses: ArtiomTr/jest-coverage-report-action@v2
+        uses: ArtiomTr/jest-coverage-report-action@v2.3.1
         with:
           skip-step: install
           annotations: failed-tests

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ on:
 
   push:
     branches:
-      - main
+      - hemi-main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,6 +12,8 @@ concurrency:
 
 jobs:
   test:
+    permissions:
+      checks: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/hooks/__tests__/useChainId.test.ts
+++ b/src/hooks/__tests__/useChainId.test.ts
@@ -56,7 +56,7 @@ describe('useChainId hook', () => {
 
   it('should return the default chainId if no query params', () => {
     const { result } = renderHook(() => useChainId())
-    expect(result.current).toBe('11155111')
+    expect(result.current).toBe('743111')
   })
 
   it('should return the chainId based on the chain query', () => {


### PR DESCRIPTION
## What it solves

The `Unit tests.jobs.test` job fails.

## How this PR fixes it

Upstream updated the action used in this job. Updating to the same version and fixing a chain ID that now defaults to Hemi Sepolia fixed all the errors.

## How to test it

See the checks in this PR passing.