### PR TITLE
Bump actions/upload-artifact to 4

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -32,7 +32,7 @@ jobs:
         run: npx -p nextjs-bundle-analysis report
 
       - name: Upload bundle
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: bundle
           path: .next/analyze/__bundle_analysis.json


### PR DESCRIPTION
## What it solves

`actions/upload-artifact@v3` is scheduled for deprecation on November 30, 2024.

## How this PR fixes it

Just updates the action to v4 by cherry-picking the upstream commit.

## Checklist

- [ ] I've tested the branch on mobile 📱
- [ ] I've documented how it affects the analytics (if at all) 📊
- [ ] I've written a unit/e2e test for it (if applicable) 🧑‍💻
