### PR TITLE
Fix unit test and bundle analysis workflows

### DIFF
--- a/.github/workflows/nextjs-bundle-analysis.yml
+++ b/.github/workflows/nextjs-bundle-analysis.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   push:
     branches:
-      - dev
+      - hemi-main
 
 permissions:
   contents: read # for checkout repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,8 +13,9 @@ concurrency:
 jobs:
   test:
     permissions:
-      contents: read
+      actions: write
       checks: write
+      contents: read
       pull-requests: write
 
     runs-on: ubuntu-latest

--- a/scripts/github/download_bundle_analyser_artifact.sh
+++ b/scripts/github/download_bundle_analyser_artifact.sh
@@ -1,12 +1,12 @@
 # We use this instead of action-download-artifact. See discussion on
 # https://github.com/dawidd6/action-download-artifact/issues/240
 set -xe
-ORG="safe-global"
+ORG="hemilabs"
 REPO="safe-wallet-web"
 WORKFLOW="nextjs-bundle-analysis.yml"
 ARTIFACT_NAME="bundle"
 DESTINATION=".next/analyze/base"
-BASE_BRANCH="dev"
+BASE_BRANCH="hemi-main"
 
 ARTIFACTS_URL=$(
   gh api \


### PR DESCRIPTION
## What it solves

Resolves part of #3 by allowing the unit tests to write the results report. The tests were passing but the action was failing because of a lack of permissions to write the report!

It also fixes the Next.js bundle analysis by uploading and downloading the bundles from the proper organization (hemilabs) and branch (hemi-main). Note that until this PR is merged, the bundle analysis will fail as there is no "base" bundle to compare against.
